### PR TITLE
Fix version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, install the library by adding `revisionair_ecto` to your list of dependen
 
 ```elixir
 def deps do
-  [{:revisionair_ecto, "~> 1.0.0"}]
+  [{:revisionair_ecto, "~> 1.0"}]
 end
 ```
 


### PR DESCRIPTION
While the latest version of the library is `1.2.2` the README specifies versions which are `1.0.X`, as a result of this newer elixir projects will complain about uncompatible versions of other dependencies (eg ecto). This can lead to frustrated developers who are blindly following the guide.

![Screenshot 2020-09-18 at 10 18 57](https://user-images.githubusercontent.com/57303/93577964-fd69b880-f99c-11ea-81b5-38d9a203f265.png)
![Screenshot 2020-09-18 at 10 18 50](https://user-images.githubusercontent.com/57303/93577952-fa6ec800-f99c-11ea-9c82-a3ab95e287a5.png)

